### PR TITLE
Clarify oxygen measure

### DIFF
--- a/PIRDS-v.0.1.md
+++ b/PIRDS-v.0.1.md
@@ -31,7 +31,7 @@ The Types are:
 2. P : Pressure: cm H2O (a medical standard) times 10
 2. D : Differential pressure: cm H2O (a medical standard) times 10 (the same unit, but RELATIVE, not ABSOLUTE)
 3. F : Flow slm (liters at 0C per minute) times 1000
-4. O : FiO2 (fractional oxygen) times 100 (thus a percentage)
+4. O : FO2 (fractional oxygen) times 100 (thus a percentage)
 5. H : humidity (% humidity ???) times 100
 6. V : Volume in millilieters
 7. B : Breaths per minute times 10


### PR DESCRIPTION
Generally oxygen is measured continually at the Y adapter (or the `A` location), thus both FiO2 and FeO2 are derivable. In some locations (where I have not seen measurements taken, a pure FiO2 or FeO2 would be measured. 

To extract FiO2 from a FO2 trace, would, I imagine, require reference to the capnography trace, more simply taking the peak values (as patients extract oxygen from the gas, thus the inspired number is most likely the highest we've seen recently)